### PR TITLE
fix: remove frappe as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-frappe
-erpnext
+# frappe   # https://github.com/frappe/frappe is installed during bench-init
+# erpnext   # https://github.com/frappe/erpnext is installed during bench-init
 ShopifyAPI==8.4.1


### PR DESCRIPTION
For Python3.7+ compatibility.

With its new dependency resolver, pip tries to first install `frappe` using pypi, which exists but doesn't belong to Frappe Tech. This causes installation to fail.

**Ref:** https://github.com/frappe/erpnext/pull/25501