### PR TITLE
fix: update Shopify API version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # frappe   # https://github.com/frappe/frappe is installed during bench-init
 # erpnext   # https://github.com/frappe/erpnext is installed during bench-init
-ShopifyAPI~=10.0.0
+ShopifyAPI~=11.0.0

--- a/shopify_integration/shopify_integration/doctype/shopify_settings/shopify_settings.py
+++ b/shopify_integration/shopify_integration/doctype/shopify_settings/shopify_settings.py
@@ -15,7 +15,7 @@ from shopify_integration.shopify_integration.doctype.shopify_log.shopify_log imp
 
 
 class ShopifySettings(Document):
-	api_version = "2021-01"
+	api_version = "2022-04"
 
 	@staticmethod
 	@frappe.whitelist()


### PR DESCRIPTION
Frappe is seeing a bunch of errors due to outdated API versions (ref: https://github.com/frappe/ecommerce_integrations/pull/181)